### PR TITLE
Initialize FastAPI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# Introduction to GitHub
+# STOCKERRA
 
-<img src="https://octodex.github.com/images/Professortocat_v2.png" align="right" height="200px" />
+Cloud based inventory management system.
 
-Hey @berkayC01!
+This repository contains a minimal FastAPI backend prototype. Features include:
 
-Mona here. I'm done preparing your exercise. Hope you enjoy! 💚
+- Product management with categories and brands
+- Stock transaction tracking (in/out/transfer)
+- Basic in-memory storage for demonstration
 
-Remember, it's self-paced so feel free to take a break! ☕️
+The backend code is located in `backend/`.
 
-[![](https://img.shields.io/badge/Go%20to%20Exercise-%E2%86%92-1f883d?style=for-the-badge&logo=github&labelColor=197935)](https://github.com/berkayC01/stok-takip/issues/1)
-
----
-
-&copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
-
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn main:app --reload
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# STOCKERRA Backend
+
+Minimal FastAPI backend for inventory management.
+
+Run locally with:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="STOCKERRA")
+
+# Placeholder in-memory storage
+products_db = {}
+transactions_db = []
+
+
+class Product(BaseModel):
+    id: int
+    name: str
+    category: str
+    brand: str
+    barcode: str
+    skt: str
+    stock_level: int = 0
+
+
+class ProductCreate(BaseModel):
+    name: str
+    category: str
+    brand: str
+    barcode: str
+    skt: str
+
+
+class TransactionType(str, Enum):
+    IN = "IN"
+    OUT = "OUT"
+    TRANSFER = "TRANSFER"
+
+
+class StockTransaction(BaseModel):
+    product_id: int
+    quantity: int
+    type: TransactionType
+
+
+@app.post("/products/", response_model=Product)
+async def create_product(product: ProductCreate):
+    product_id = len(products_db) + 1
+    prod = Product(id=product_id, **product.dict())
+    products_db[product_id] = prod
+    return prod
+
+
+@app.get("/products/", response_model=List[Product])
+async def list_products():
+    return list(products_db.values())
+
+
+@app.post("/stocks/transactions", response_model=StockTransaction)
+async def add_transaction(transaction: StockTransaction):
+    if transaction.product_id not in products_db:
+        raise HTTPException(status_code=404, detail="Product not found")
+    if transaction.quantity <= 0:
+        raise HTTPException(status_code=400, detail="Quantity must be positive")
+
+    transactions_db.append(transaction)
+    prod = products_db[transaction.product_id]
+    if transaction.type == TransactionType.IN:
+        prod.stock_level += transaction.quantity
+    elif transaction.type == TransactionType.OUT:
+        prod.stock_level -= transaction.quantity
+    # TRANSFER does not change stock level in this simple example
+    return transaction
+
+
+@app.get("/stocks/transactions", response_model=List[StockTransaction])
+async def list_transactions():
+    return transactions_db

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- set up a minimal FastAPI backend in `backend/`
- add product and stock transaction endpoints with in-memory storage
- document how to run the backend in `README.md`
- fix minor prototype issues and simplify requirements

## Testing
- `pip install black`
- `black -q backend/main.py`
- `pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687642fe2594832a986d20784da1cd41